### PR TITLE
Make Searchbar init on Framework7 1.0.5

### DIFF
--- a/app/templates/components/f7-search-bar.hbs
+++ b/app/templates/components/f7-search-bar.hbs
@@ -1,5 +1,5 @@
 <!-- Search bar -->
-<form {{bind-attr data-search-list=searchList data-search-in=searchIn}} class="searchbar">
+<form {{bind-attr data-search-list=searchList data-search-in=searchIn}} class="searchbar searchbar-init">
   <div class="searchbar-input">
     {{input type='search' value=query placeholder=placeholder}}<a href="#" class="searchbar-clear"></a>
   </div><a href="#" class="searchbar-cancel">{{cancelText}}</a>


### PR DESCRIPTION
Currently, the init code does not run under Framework7 v1.0.5,
because it now has this guard that is absent in 0.10.0:

    if (!searchbar.hasClass('searchbar-init')) return;

It seems to be sufficient to add this class into the searchbar
template to make it work properly, while it shouldn't have any
effect on an earlier version.