### PR TITLE
Removes a deprecation warning and bumps the version of Framework 7

### DIFF
--- a/app/initializers/framework7-service.js
+++ b/app/initializers/framework7-service.js
@@ -1,4 +1,4 @@
-export function initialize(container, application) {
+export function initialize(application) {
   application.inject('route', 'f7', 'service:framework7')
   application.inject('controller', 'f7', 'service:framework7')
   application.inject('component', 'f7', 'service:framework7')

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0",
-    "framework7": "~0.10.0"
+    "framework7": "~1.4.2"
   }
 }


### PR DESCRIPTION
The removal of the `container` argument seems not to impact the functionality but I'm only 90% convinced.