### PR TITLE
Missing comma is causing the after install hook to fail

### DIFF
--- a/blueprints/ember-cli-framework7/index.js
+++ b/blueprints/ember-cli-framework7/index.js
@@ -1,6 +1,6 @@
 /*jshint node:true*/
 module.exports = {
-  description: ''
+  description: '',
 
   // locals: function(options) {
   //   // Return custom template variables here.


### PR DESCRIPTION
The after install hook is failing with a syntax error because of a missing comma in the blueprint. 