### PR TITLE
Fix error when initializing the search bar

### DIFF
--- a/app/components/f7-search-bar.js
+++ b/app/components/f7-search-bar.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
     if (searchList.length > 1) {
       throw new Error('There is more then one search list available within the search component.');
     }
-    this.get('f7.f7').initSearchbar('.searchbar');
+    this.get('f7.f7').initSearchbar(this.$('.searchlist'));
   },
 
   onQueryChanged: function() {

--- a/app/components/f7-search-bar.js
+++ b/app/components/f7-search-bar.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
     if (searchList.length > 1) {
       throw new Error('There is more then one search list available within the search component.');
     }
-    this.get('f7.f7').initSearchbar(this.$());
+    this.get('f7.f7').initSearchbar('.searchbar');
   },
 
   onQueryChanged: function() {


### PR DESCRIPTION
Search bar component init throws an error since we cannot use this.$() on components where tagName is ''. Instead we pass the classname of the searchbar container.