### PR TITLE
Upgrade ember-cli to 2.15 and ember-cli-babel to 6.6.0

### DIFF
--- a/addon/services/f7.js
+++ b/addon/services/f7.js
@@ -1,7 +1,7 @@
 /* globals Framework7 */
-import Ember from 'ember';
-
-const { Service, computed } = Ember;
+import Service from '@ember/service';
+import { computed }  from '@ember/object';
+import $ from 'jquery';
 
 export default Service.extend({
   f7: null,
@@ -23,7 +23,7 @@ export default Service.extend({
   _f7Init() {
     const f7 = this.get('f7');
     if(f7.theme){
-      Ember.$('body').addClass(f7.theme);
+      $('body').addClass(f7.theme);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-node-assets": "0.1.6",
     "framework7": "^1.5.2"
@@ -25,7 +25,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "2.11.0",
+    "ember-cli": "2.15.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",


### PR DESCRIPTION
This PR fix the constant warning saying that one should be using 6.6+ babel. This has been constantly showing up in every $ember serve